### PR TITLE
I2c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 STM32Cube/Debug/*
+STM32Cube/Release/*
 STM32Cube/.settings
 .metadata
 .settings

--- a/STM32Cube/Core/Inc/ICM-20948.h
+++ b/STM32Cube/Core/Inc/ICM-20948.h
@@ -17,12 +17,22 @@ bool ICM_20948_check_sanity(void);
 // Perform magnetometer self-test procedure according to datasheet
 bool MAG_Self_Test(void);
 
-// Get IMU data: accelerometer, gyroscope, magnetometer, and temperature
+/**
+ * Get current accelerometer reading synchronously (blocking)
+ * @return (gravities)
+*/
+bool ICM_20948_get_accel_converted(float *x, float *y, float *z);
 
-bool ICM_20948_get_accel_raw(int16_t *x, int16_t *y, int16_t *z);
+/**
+ * Get current gyroscope reading synchronously (blocking)
+ * @return (deg/sec)
+*/
+bool ICM_20948_get_gyro_converted(float *x, float *y, float *z);
 
-bool ICM_20948_get_gyro_raw(int16_t *x, int16_t *y, int16_t *z);
-
-bool ICM_20948_get_mag_raw(int16_t *x, int16_t *y, int16_t *z);
+/**
+ * Get current magnetometer reading synchronously (blocking)
+ * @return (microteslas)
+*/
+bool ICM_20948_get_mag_converted(float *x, float *y, float *z);
 
 #endif	/* ICM_20948_H */

--- a/STM32Cube/Core/Inc/my2c.h
+++ b/STM32Cube/Core/Inc/my2c.h
@@ -12,10 +12,4 @@ HAL_StatusTypeDef MY2C_write1ByteRegister(uint8_t address, uint8_t reg, uint8_t 
 
 uint8_t MY2C_read1ByteRegister(uint8_t address, uint8_t reg);
 
-void I2C4_MemTxCallback(I2C_HandleTypeDef* hi2c4);
-
-void I2C4_MemRxCallback(I2C_HandleTypeDef* hi2c4);
-
-void I2C4_ErrorCallback(I2C_HandleTypeDef* hi2c4);
-
 #endif	/* MY2C_H */

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -857,30 +857,30 @@ void stateEstimationTask(void *argument)
 		// handle i2c sanity check failure?
     }
 
-    int16_t magData[3];
-    int16_t accelData[3];
-    int16_t gyroData[3];
+    float magData[3];
+    float accelData[3];
+    float gyroData[3];
+    //int len;
+    //char dataStr[50];
 
   /* Infinite loop */
     for(;;)
     {
-        ICM_20948_get_mag_raw(magData, magData + 1, magData + 2);
-        ICM_20948_get_accel_raw(accelData, accelData + 1, accelData + 2);
-        ICM_20948_get_gyro_raw(gyroData, gyroData + 1, gyroData + 2);
+        ICM_20948_get_mag_converted(magData, magData + 1, magData + 2);
+        ICM_20948_get_accel_converted(accelData, accelData + 1, accelData + 2);
+        ICM_20948_get_gyro_converted(gyroData, gyroData + 1, gyroData + 2);
 
-        // very scuffed serial printing for testing
-        /*
-        char dataStr[50];
-        char* newLine = "\n";
+        // TODO: look into how better manage snprintf to not cause death (esp with %f)
+		/*
+        // FOR TESTING: serial print data
+        len = snprintf(dataStr, 50, "mag: %.3f, %.3f, %.3f\n", magData[0], magData[1], magData[2]);
+        //HAL_UART_Transmit(&huart4, (uint8_t) dataStr, len, 500);
 
-        int len = snprintf(dataStr, 50, "mag: %hd, %hd, %hd\n", magData[0], magData[1], magData[2]);
-        HAL_UART_Transmit(&huart4, dataStr, len, 500);
+		len = snprintf(dataStr, 50, "accel: %.3f, %.3f, %.3f\n", accelData[0], accelData[1], accelData[2]);
+        //HAL_UART_Transmit(&huart4, dataStr, len, 500);
 
-        len = snprintf(dataStr, 50, "accel: %hd, %hd, %hd\n", accelData[0], accelData[1], accelData[2]);
-        HAL_UART_Transmit(&huart4, dataStr, len, 500);
-
-        len = snprintf(dataStr, 50, "gyro: %hd, %hd, %hd\n", gyroData[0], gyroData[1], gyroData[2]);
-        HAL_UART_Transmit(&huart4, dataStr, len, 500);
+        len = snprintf(dataStr, 50, "gyro: %.3f, %.3f, %.3f\n", gyroData[0], gyroData[1], gyroData[2]);
+		//HAL_UART_Transmit(&huart4, dataStr, len, 500);
         */
 	    idx++;
         osDelay(100);

--- a/STM32Cube/Core/Src/my2c.c
+++ b/STM32Cube/Core/Src/my2c.c
@@ -7,11 +7,18 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 
-SemaphoreHandle_t I2C4BinarySemaphore;
-
 extern I2C_HandleTypeDef hi2c4;
 
-uint8_t timeout_MS = 200;
+SemaphoreHandle_t I2C4BinarySemaphore;
+
+/* Max timeout to wait for read/write semaphore */
+static const uint8_t timeout_MS = 200;
+
+/* Callback function definitions */
+void I2C4_MemRxCallback(I2C_HandleTypeDef* hi2c4);
+void I2C4_MemTxCallback(I2C_HandleTypeDef* hi2c4);
+void I2C4_ErrorCallback(I2C_HandleTypeDef* hi2c4);
+
 
 /**
  * Register i2c4 callbacks, semaphore


### PR DESCRIPTION
Add icm raw data to actual units conversion.

Outputs the data in floats now. Is this the desired data type?

RELEVANT SIDE NOTE: snprintf does not do %f formatting well... causes hardfault very quickly.
- Sprintf is a very large function apparently and needs a lot of stack
  - Increasing the StateEst task stack size to an arbitrarily large value seemed to fix this (only tested; didn't commit)
- Some sources suggest the sprintf functions might use malloc ???