### PR TITLE
Otits changes and adding tests

### DIFF
--- a/STM32Cube/Core/Src/ICM-20948.c
+++ b/STM32Cube/Core/Src/ICM-20948.c
@@ -147,9 +147,9 @@ bool ICM_20948_init() {
     MY2C_write1ByteRegister(AK09916_MAG_ADDR, CNTL2, 0x06);
 
 #ifdef TEST_MODE
-    otitsRegister(test_ICMSanity, TEST_SOURCE_ICM);
-    otitsRegister(test_magSanity, TEST_SOURCE_ICM);
-    otitsRegister(test_magSelfTest, TEST_SOURCE_ICM);
+    otitsRegister(test_ICMSanity, TEST_SOURCE_ICM, "ICMSanity");
+    otitsRegister(test_magSanity, TEST_SOURCE_ICM, "MagSanity");
+    otitsRegister(test_magSelfTest, TEST_SOURCE_ICM, "MagSelfTest");
     return true;
 #endif
 }

--- a/STM32Cube/Core/Src/ICM-20948.c
+++ b/STM32Cube/Core/Src/ICM-20948.c
@@ -14,7 +14,6 @@ static const float ACCEL_SENSITIVITY = 2048;
 static const float MAG_SENSITIVITY = 0.15;
 
 // OTITS TESTS
-#ifdef TEST_MODE
 Otits_Result_t test_ICMSanity() {
 	Otits_Result_t res;
 
@@ -104,8 +103,6 @@ Otits_Result_t test_magSelfTest() {
 	res.outcome = TEST_OUTCOME_PASSED;
 	return res;
 }
-#endif
-
 
 // This driver assumes that I2C is already initialized
 bool ICM_20948_init() {
@@ -146,12 +143,10 @@ bool ICM_20948_init() {
     // Set to continuous measurement mode 3 (50 Hz measurement frequency)
     MY2C_write1ByteRegister(AK09916_MAG_ADDR, CNTL2, 0x06);
 
-#ifdef TEST_MODE
     otitsRegister(test_ICMSanity, TEST_SOURCE_ICM, "ICMSanity");
     otitsRegister(test_magSanity, TEST_SOURCE_ICM, "MagSanity");
     otitsRegister(test_magSelfTest, TEST_SOURCE_ICM, "MagSelfTest");
     return true;
-#endif
 }
 
 bool ICM_20948_check_sanity(void) {

--- a/STM32Cube/Core/Src/ICM-20948.c
+++ b/STM32Cube/Core/Src/ICM-20948.c
@@ -4,6 +4,7 @@
 #include "ICM-20948.h"
 #include "ICM-20948_regmap.h"
 #include "cmsis_os.h"
+#include "otits.h"
 
 /* LSB / (deg/sec) */
 static const float GYRO_SENSITIVITY = 16.4;
@@ -11,6 +12,100 @@ static const float GYRO_SENSITIVITY = 16.4;
 static const float ACCEL_SENSITIVITY = 2048;
 /* microteslas / LSB */
 static const float MAG_SENSITIVITY = 0.15;
+
+// OTITS TESTS
+#ifdef TEST_MODE
+Otits_Result_t test_ICMSanity() {
+	Otits_Result_t res;
+
+	if (MY2C_write1ByteRegister(ICM_20948_ADDR, REG_BANK_SEL, 0x00) != HAL_OK){
+		res.info = "my2c write fail";
+		res.outcome = TEST_OUTCOME_FAILED;
+		return res;
+	} else if (MY2C_read1ByteRegister(ICM_20948_ADDR, WHO_AM_I) != 0xEA) {
+		res.info = "icm who-am-i value incorrect";
+		res.outcome = TEST_OUTCOME_DATA_ERR;
+		return res;
+    }
+	res.info = "";
+	res.outcome = TEST_OUTCOME_PASSED;
+	return res;
+}
+
+Otits_Result_t test_magSanity() {
+	Otits_Result_t res;
+
+    if (MY2C_read1ByteRegister(AK09916_MAG_ADDR, WIA2) != 0x09) {
+		res.info = "mag who-am-i value incorrect";
+		res.outcome = TEST_OUTCOME_DATA_ERR;
+		return res;
+    }
+	res.info = "";
+	res.outcome = TEST_OUTCOME_PASSED;
+	return res;
+}
+
+Otits_Result_t test_magSelfTest() {
+	Otits_Result_t res;
+	HAL_StatusTypeDef status = HAL_OK;
+
+    // reset to power-down mode
+    status |= MY2C_write1ByteRegister(AK09916_MAG_ADDR, CNTL2, 0x0);
+    vTaskDelay(50);
+    // set self-test mode
+    status |= MY2C_write1ByteRegister(AK09916_MAG_ADDR, CNTL2, 0x10);
+    vTaskDelay(50);
+
+    // bit 1 of this reg indicates whether data is ready
+    uint8_t mag_data_status_1 = MY2C_read1ByteRegister(AK09916_MAG_ADDR, ST1);
+    vTaskDelay(50);
+
+    // wait until data is ready
+    if (!(mag_data_status_1 & 1)) {
+    	res.info = "mag selftest data not ready";
+    	res.outcome = TEST_OUTCOME_FAILED;
+    	return res;
+    }
+
+    // get data
+    int16_t x = 0;
+    int16_t y = 0;
+    int16_t z = 0;
+
+    uint8_t x_h = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HXH);
+    uint8_t x_l = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HXL);
+    x = (int16_t)((uint16_t)x_h << 8 | x_l);
+
+    uint8_t y_h = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HYH);
+    uint8_t y_l = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HYL);
+    y = (int16_t)((uint16_t)y_h << 8 | y_l);
+
+    uint8_t z_h = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HZH);
+    uint8_t z_l = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HZL);
+    z = (int16_t)((uint16_t)z_h << 8 | z_l);
+
+    // Must read ST2 register after measurement, see datasheet register 13.4 ST2
+    MY2C_read1ByteRegister(AK09916_MAG_ADDR, ST2);
+    // exit self test mode
+    status |= MY2C_write1ByteRegister(AK09916_MAG_ADDR, CNTL2, 0x06);
+
+    // validate data according to self-test thresholds on datasheet
+    if (status != HAL_OK) {
+    	res.info = "mag selftest my2c fail";
+    	res.outcome = TEST_OUTCOME_FAILED;
+    	return res;
+    }
+    if (!(-200 <= x && x <= 200  && -200 <= y && y <= 200 && -1000 <= z && z <= -200)) {
+    	res.info = "mag selftest data out of bounds";
+    	res.outcome = TEST_OUTCOME_DATA_ERR;
+    	return res;
+    }
+	res.info = "";
+	res.outcome = TEST_OUTCOME_PASSED;
+	return res;
+}
+#endif
+
 
 // This driver assumes that I2C is already initialized
 bool ICM_20948_init() {
@@ -51,7 +146,12 @@ bool ICM_20948_init() {
     // Set to continuous measurement mode 3 (50 Hz measurement frequency)
     MY2C_write1ByteRegister(AK09916_MAG_ADDR, CNTL2, 0x06);
 
+#ifdef TEST_MODE
+    otitsRegister(test_ICMSanity, TEST_SOURCE_ICM);
+    otitsRegister(test_magSanity, TEST_SOURCE_ICM);
+    otitsRegister(test_magSelfTest, TEST_SOURCE_ICM);
     return true;
+#endif
 }
 
 bool ICM_20948_check_sanity(void) {
@@ -68,52 +168,6 @@ bool ICM_20948_check_sanity(void) {
 
     // checks pass
     return true;
-}
-
-/**
- * Perform AK09916 self-test procedure according to datasheet
- * @return true if the data passes the self-test thresholds 
-*/
-bool MAG_Self_Test(void) {
-    // reset to power-down mode
-    MY2C_write1ByteRegister(AK09916_MAG_ADDR, CNTL2, 0x0);
-    osDelay(1000);
-    // set self-test mode
-    MY2C_write1ByteRegister(AK09916_MAG_ADDR, CNTL2, 0x10);
-    
-    // bit 1 of this reg indicates whether data is ready
-    uint8_t mag_data_status_1 = MY2C_read1ByteRegister(AK09916_MAG_ADDR, ST1);
-
-    // wait until data is ready
-    while (!(mag_data_status_1 & 1)) {
-        mag_data_status_1 = MY2C_read1ByteRegister(AK09916_MAG_ADDR, ST1);
-    }
-
-    // get data
-    int16_t x = 0;
-    int16_t y = 0;
-    int16_t z = 0;
-
-    uint8_t x_h = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HXH);
-    uint8_t x_l = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HXL);
-    x = (int16_t)((uint16_t)x_h << 8 | x_l);
-
-    uint8_t y_h = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HYH);
-    uint8_t y_l = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HYL);
-    y = (int16_t)((uint16_t)y_h << 8 | y_l);
-
-    uint8_t z_h = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HZH);
-    uint8_t z_l = MY2C_read1ByteRegister(AK09916_MAG_ADDR, HZL);
-    z = (int16_t)((uint16_t)z_h << 8 | z_l);
-
-    // Must read ST2 register after measurement, see datasheet register 13.4 ST2
-    MY2C_read1ByteRegister(AK09916_MAG_ADDR, ST2);
-
-    // validate data according to self-test thresholds on datasheet
-    if (-200 <= x && x <= 200  && -200 <= y && y <= 200 && -1000 <= z && z <= -200) { 
-        return true;
-    }
-    return false;
 }
 
 bool ICM_20948_get_accel_raw(int16_t *x, int16_t *y, int16_t *z) 

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -226,8 +226,8 @@ int main(void)
   //xReturned &= xTaskCreate(controlTask, "Controller", 2000, NULL, (UBaseType_t) osPriorityBelowNormal, &controllerHandle);
   //xReturned &= xTaskCreate(flightPhaseTask, "Flight Phase", 2000, NULL, (UBaseType_t) osPriorityAboveNormal, &controllerHandle);
 #ifdef TEST_MODE
-  otitsRegister(test_defaultTaskPass, TEST_SOURCE_DEFAULT);
-  otitsRegister(test_defaultTaskFail, TEST_SOURCE_DEFAULT);
+  otitsRegister(test_defaultTaskPass, TEST_SOURCE_DEFAULT, "DefaultPass");
+  otitsRegister(test_defaultTaskFail, TEST_SOURCE_DEFAULT, "DefaultFail");
   xReturned &= xTaskCreate(otitsTask, "oTITS", 500, NULL, (UBaseType_t) osPriorityBelowNormal, &oTITSHandle);
 #endif
 

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -26,6 +26,7 @@
 #include "printf.h"
 #include "canlib.h"
 #include "millis.h"
+#include "ICM-20948.h"
 
 #include "vn_handler.h"
 #include "log.h"
@@ -1010,6 +1011,8 @@ static void MX_GPIO_Init(void)
 /* USER CODE END Header_StartDefaultTask */
 void StartDefaultTask(void *argument)
 {
+	// THIS FUNCTION MUST BE CALLED INSIDE A FREERTOS TASK
+	ICM_20948_init();
   /* USER CODE BEGIN 5 */
 	/* Infinite loop */
 	for(;;)

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -27,6 +27,7 @@
 #include "canlib.h"
 #include "millis.h"
 #include "ICM-20948.h"
+#include "my2c.h"
 
 #include "vn_handler.h"
 #include "log.h"
@@ -203,6 +204,7 @@ int main(void)
   canHandlerInit(); //create bus queue
   flightPhaseInit();
   logInit();
+  MY2C_init();
   //canHandlerInit(); //create bus queue
   //flightPhaseInit();
   otitsRegister(test_defaultTaskPass, TEST_SOURCE_DEFAULT, "DefaultPass");

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -120,7 +120,6 @@ void StartDefaultTask(void *argument);
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
-#ifdef TEST_MODE
 Otits_Result_t test_defaultTaskPass() {
 	Otits_Result_t res;
 	res.info = "this should pass";
@@ -134,7 +133,6 @@ Otits_Result_t test_defaultTaskFail() {
 	res.outcome = TEST_OUTCOME_FAILED;
 	return res;
 }
-#endif
 /* USER CODE END 0 */
 
 /**
@@ -207,6 +205,8 @@ int main(void)
   logInit();
   //canHandlerInit(); //create bus queue
   //flightPhaseInit();
+  otitsRegister(test_defaultTaskPass, TEST_SOURCE_DEFAULT, "DefaultPass");
+  otitsRegister(test_defaultTaskFail, TEST_SOURCE_DEFAULT, "DefaultFail");
   /* USER CODE END RTOS_QUEUES */
 
   /* Create the thread(s) */
@@ -226,8 +226,6 @@ int main(void)
   //xReturned &= xTaskCreate(controlTask, "Controller", 2000, NULL, (UBaseType_t) osPriorityBelowNormal, &controllerHandle);
   //xReturned &= xTaskCreate(flightPhaseTask, "Flight Phase", 2000, NULL, (UBaseType_t) osPriorityAboveNormal, &controllerHandle);
 #ifdef TEST_MODE
-  otitsRegister(test_defaultTaskPass, TEST_SOURCE_DEFAULT, "DefaultPass");
-  otitsRegister(test_defaultTaskFail, TEST_SOURCE_DEFAULT, "DefaultFail");
   xReturned &= xTaskCreate(otitsTask, "oTITS", 500, NULL, (UBaseType_t) osPriorityBelowNormal, &oTITSHandle);
 #endif
 

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -205,6 +205,8 @@ int main(void)
   canHandlerInit(); //create bus queue
   flightPhaseInit();
   logInit();
+  //canHandlerInit(); //create bus queue
+  //flightPhaseInit();
   /* USER CODE END RTOS_QUEUES */
 
   /* Create the thread(s) */
@@ -219,7 +221,7 @@ int main(void)
   //xReturned &= xTaskCreate(vnIMUHandler, "VN Task", 2000, NULL, (UBaseType_t) osPriorityNormal, &VNTaskHandle);
   //xReturned &= xTaskCreate(canHandlerTask, "CAN handler", 2000, NULL, (UBaseType_t) osPriorityNormal, &canhandlerhandle);
   //xReturned &= xTaskCreate(stateEstTask, "StateEst", 2000, NULL, (UBaseType_t) osPriorityNormal, &stateEstTaskHandle);
-  //xReturned &= xTaskCreate(logTask, "Logging", 2000, NULL, (UBaseType_t) osPriorityBelowNormal, &logTaskhandle);
+  xReturned &= xTaskCreate(logTask, "Logging", 1024, NULL, (UBaseType_t) osPriorityBelowNormal, &logTaskhandle);
   //xReturned &= xTaskCreate(healthCheckTask, "health checks", 2000, NULL, (UBaseType_t) osPriorityNormal, &healthChecksTaskHandle);
   //xReturned &= xTaskCreate(controlTask, "Controller", 2000, NULL, (UBaseType_t) osPriorityBelowNormal, &controllerHandle);
   //xReturned &= xTaskCreate(flightPhaseTask, "Flight Phase", 2000, NULL, (UBaseType_t) osPriorityAboveNormal, &controllerHandle);

--- a/STM32Cube/Tasks/log.c
+++ b/STM32Cube/Tasks/log.c
@@ -15,7 +15,6 @@ static SemaphoreHandle_t logWriteMutex;
 QueueHandle_t fullBuffersQueue;
 
 // OTITS TESTS
-#ifdef TEST_MODE
 Otits_Result_t test_logInfo() {
 	Otits_Result_t res;
 	if (!logInfo("otits-test", "otits!")){
@@ -39,7 +38,6 @@ Otits_Result_t test_currentBufferFull() {
 	res.outcome = TEST_OUTCOME_PASSED;
 	return res;
 }
-#endif
 
 bool logInit(void) {
     fullBuffersQueue = xQueueCreate(NUM_LOG_BUFFERS - 1, sizeof(log_buffer*));

--- a/STM32Cube/Tasks/log.c
+++ b/STM32Cube/Tasks/log.c
@@ -53,9 +53,8 @@ bool logInit(void) {
         logBuffers[i].index = 0;
         logBuffers[i].isFull = false;
     }
-
-    otitsRegister(test_currentBufferFull, TEST_SOURCE_LOGGER);
-    otitsRegister(test_logInfo, TEST_SOURCE_LOGGER);
+    otitsRegister(test_currentBufferFull, TEST_SOURCE_LOGGER, "CurrBufFull");
+    otitsRegister(test_logInfo, TEST_SOURCE_LOGGER, "LogInfo");
     return true;
 }
 

--- a/STM32Cube/Tasks/otits.c
+++ b/STM32Cube/Tasks/otits.c
@@ -20,6 +20,7 @@ static Otits_Test tests[MAX_NUM_TESTS] = {};
 static int numTestsRegistered = 0;
 
 static char* testOutcomeStrings[TEST_OUTCOME_ENUM_MAX] = {
+		"ENUM UNSPECIFIED",
 		"PASS",
 		"FAIL",
 		"TIMEOUT",
@@ -57,10 +58,10 @@ static Otits_Result_t otitsRunTest(Otits_Test* test) {
 	test->lastRunTime = xTaskGetTickCount();
 	test->totalRuns++;
 	if (result.outcome != TEST_OUTCOME_PASSED) {
-	    printf_("TEST [%d] FAILED: id:%d, %s | Info: %s\n", (int) xTaskGetTickCount(), currentTestId, testOutcomeStrings[result.outcome], result.info);
+		printf_("TEST [%d] FAILED: id:%d, %s | Info: %s\n", (int) xTaskGetTickCount(), currentTestId, testOutcomeStrings[result.outcome], result.info);
 		test->runsFailed++;
 	} else {
-	    printf_("TEST [%d] passed: %s | %s\n", (int) xTaskGetTickCount(), testOutcomeStrings[result.outcome], result.info);
+		printf_("TEST [%d] passed: id:%d, %s | Info: %s\n", (int) xTaskGetTickCount(), currentTestId, testOutcomeStrings[result.outcome], result.info);
 	}
 
 	return result;
@@ -78,7 +79,7 @@ void otitsPrintAllResults() {
 				testOutcomeStrings[tests[i].latestOutcome], tests[i].runsFailed, tests[i].totalRuns);
 	}
 	len += snprintf_(resultString + len, RESULT_STRING_LENGTH - len,  "[%d]******************\n\n", (int) xTaskGetTickCount());
-	HAL_UART_Transmit(&huart4, (uint8_t*) resultString, len, 50);
+	HAL_UART_Transmit(&huart4, (uint8_t*) resultString, len, 250);
 }
 
 /**

--- a/STM32Cube/Tasks/otits.h
+++ b/STM32Cube/Tasks/otits.h
@@ -8,7 +8,6 @@
 // MAXIMUM NUMBER OF TESTS ALLOWED TO BE REGISTERED
 #define MAX_NUM_TESTS 30
 
-extern UART_HandleTypeDef huart4;
 /**
  * Log data source
 */
@@ -61,6 +60,7 @@ typedef Otits_Result_t Otits_Test_Function_t(void);
  */
 typedef struct Otits_Test {
 	int id;
+	const char* name;
 	OtitsSource_e source;
 	Otits_Test_Function_t* testFunctionPtr;
 	OtitsTestOutcome_e latestOutcome;
@@ -71,7 +71,7 @@ typedef struct Otits_Test {
 
 
 extern void otitsTask(void *arg);
-extern bool otitsRegister(Otits_Test_Function_t* testFunctionPtr, OtitsSource_e source);
+bool otitsRegister(Otits_Test_Function_t* testFunctionPtr, OtitsSource_e source, const char* name);
 #endif
 #endif /* MAIN_OTITS_H_ */
 

--- a/STM32Cube/Tasks/otits.h
+++ b/STM32Cube/Tasks/otits.h
@@ -1,6 +1,5 @@
 #ifndef MAIN_OTITS_H_
 #define MAIN_OTITS_H_
-#ifdef TEST_MODE
 
 #include <stdbool.h>
 #include "stm32h7xx_hal.h"
@@ -72,6 +71,5 @@ typedef struct Otits_Test {
 
 extern void otitsTask(void *arg);
 bool otitsRegister(Otits_Test_Function_t* testFunctionPtr, OtitsSource_e source, const char* name);
-#endif
 #endif /* MAIN_OTITS_H_ */
 

--- a/STM32Cube/Tasks/otits.h
+++ b/STM32Cube/Tasks/otits.h
@@ -34,6 +34,7 @@ typedef enum {
  * Completion status of one test run
  */
 typedef enum OtitsTestOutcome_e {
+	TEST_OUTCOME_UNSPECIFIED,
 	TEST_OUTCOME_PASSED,
 	TEST_OUTCOME_FAILED,
 	TEST_OUTCOME_TIMEOUT,


### PR DESCRIPTION
things
- add test name string to test struct. I think this is valid because the name string literals won't disappear out of scope?
- move #ifdef TEST_MODE away from otits users and into the otits files only, because it's slightly neater. At the cost of always compiling a portion of otits. But otits can just be deleted before production if needed?
- add icm tests (copied over from existing sanity and self-test functions)
- add logger tests
- add ICM_INIT in defaultTask because idk where else to put it. I think stateEst is supposed to do that but it die soo :(
- enable logger task in main.c. It should be fine even without sd card mounted? it would just log to nothingness, but at least it will process the log queue

![image](https://github.com/waterloo-rocketry/cansw_processor_stm/assets/71736183/31126519-cf9d-4924-b0e7-ccf8754b7339)
