### PR TITLE
Logger

### DIFF
--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -201,8 +201,8 @@ int main(void)
   /* USER CODE END RTOS_TIMERS */
 
   /* USER CODE BEGIN RTOS_QUEUES */
-  //canHandlerInit(); //create bus queue
-  //flightPhaseInit();
+  canHandlerInit(); //create bus queue
+  flightPhaseInit();
   logInit();
   /* USER CODE END RTOS_QUEUES */
 

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -203,7 +203,7 @@ int main(void)
   /* USER CODE BEGIN RTOS_QUEUES */
   //canHandlerInit(); //create bus queue
   //flightPhaseInit();
-  //logInit();
+  logInit();
   /* USER CODE END RTOS_QUEUES */
 
   /* Create the thread(s) */

--- a/STM32Cube/Tasks/controller.c
+++ b/STM32Cube/Tasks/controller.c
@@ -53,6 +53,10 @@ void controlTask(void *argument)
 			build_actuator_cmd_analog( (uint32_t) millis_(), ACTUATOR_AIRBRAKES_SERVO, extension, &msg);
 			xQueueSend(busQueue, &msg, 5);
 		}
+<<<<<<< HEAD
 		printf_("extension: %f", extension);
+=======
+		//printf_("extension: %f", extension);
+>>>>>>> 2c43740 (remove test printing code)
 	}
 }

--- a/STM32Cube/Tasks/controller.c
+++ b/STM32Cube/Tasks/controller.c
@@ -53,10 +53,6 @@ void controlTask(void *argument)
 			build_actuator_cmd_analog( (uint32_t) millis_(), ACTUATOR_AIRBRAKES_SERVO, extension, &msg);
 			xQueueSend(busQueue, &msg, 5);
 		}
-<<<<<<< HEAD
 		printf_("extension: %f", extension);
-=======
-		//printf_("extension: %f", extension);
->>>>>>> 2c43740 (remove test printing code)
 	}
 }

--- a/STM32Cube/Tasks/flight_phase.c
+++ b/STM32Cube/Tasks/flight_phase.c
@@ -49,7 +49,7 @@ void flightPhaseTask(void * argument)
 		{
 			flight_state = PHASE_DESCENT;
 		}
-		printf_("[%f] flight phase: %d\n", time/1000, flight_state);
+		//printf_("[%f] flight phase: %d\n", time/1000, flight_state);
 		osDelay(10);
 	}
 }

--- a/STM32Cube/Tasks/health_checks.c
+++ b/STM32Cube/Tasks/health_checks.c
@@ -30,10 +30,10 @@ void healthCheckTask(void *argument)
     uint16_t adc1_current_mA = ADC1_CURR_mA(adc1_voltage_mV);
 
     //Transmitting voltage
-    printf_( "%u mV\r\n", (uint16_t) (adc1_voltage_mV));
+    //printf_( "%u mV\r\n", (uint16_t) (adc1_voltage_mV));
 
     //Transmitting current
-    printf_("%u mA\r\n", (uint16_t) (adc1_current_mA) );;
+    //printf_("%u mA\r\n", (uint16_t) (adc1_current_mA) );;
 
     //Checking for over current
     if(adc1_current_mA > MAX_CURR_5V_mA)

--- a/STM32Cube/Tasks/log.c
+++ b/STM32Cube/Tasks/log.c
@@ -8,63 +8,25 @@ static log_buffer logBuffers[NUM_LOG_BUFFERS];
 static int CURRENT_BUFFER = 0;
 static SemaphoreHandle_t logWriteMutex;
 
-// Queue of full buffers ready for output. Length of `n - 1` because all `n` buffers can never be full at once.
-// Most extreme case: `n - 1` buffers are in queue, and the `nth` buffer is currently being dumped to output (already
-// removed from the queue and protected by mutex, so it can't be written to until the dump is done)
+// Queue of full buffers ready for output. Typically a max of `n - 1` buffers will be in queue as
+// the nth buffer is being dumped. But leave space for all `n` buffers in case queueReceive is
+// delayed. Otherwise, CURRENT_BUFFER can get stuck on a full buffer that's outside the queue.
 QueueHandle_t fullBuffersQueue;
 
-bool logInit(void)
-{
-    fullBuffersQueue = xQueueCreate(NUM_LOG_BUFFERS - 1, sizeof(log_buffer*));
+bool logInit(void) {
+    fullBuffersQueue = xQueueCreate(NUM_LOG_BUFFERS, sizeof(log_buffer*));
     logWriteMutex = xSemaphoreCreateMutex();
 
     if (fullBuffersQueue == NULL || logWriteMutex == NULL) {
         return false;
     }
 
-    for (int i = 0; i < NUM_LOG_BUFFERS; i++)
-    {
+    for (int i = 0; i < NUM_LOG_BUFFERS; i++) {
         logBuffers[i].index = 0;
         logBuffers[i].isFull = false;
     }
 
     return true;
-}
-
-/**
- * internal helper to convert source enum to string
-*/
-static const char* sourceToString(LogDataSource_t source)
-{
-    switch (source)
-    {
-        case SOURCE_FLIGHT_EVENT:
-            return "FlightEvt";
-            break;
-        case SOURCE_HEALTH: 
-            return "Health";
-            break;
-        case SOURCE_CAN_RX:
-            return "CanRx";
-            break;
-        case SOURCE_CAN_TX:
-            return "CanTx";
-            break;
-        case SOURCE_SENSOR:
-            return "Sensor";
-            break;
-        case SOURCE_STATE_EST:
-            return "StateEst";
-            break;
-        case SOURCE_APOGEE_PRED:
-            return "TrajPred";
-            break;
-        case SOURCE_EXT_TARGET :
-            return "ExtTarget";
-            break;
-        default:
-            return "";
-    }
 }
 
 /**
@@ -77,14 +39,12 @@ static const char* sourceToString(LogDataSource_t source)
  * users don't have to manually do sprintf_ beforehand - instead, this function will handle formatting the string.
  * Should be safe since this is essentially a sprintf_ wrapper, where variable arguments are acceptable.
 */
-bool logGeneric(LogDataSource_t source, LogLevel_t level, const char* msg, va_list msgArgs)
-{
+bool logGeneric(const char* source, LogLevel_t level, const char* msg, va_list msgArgs) {
     // get timestamp immediately so the following mutex wait time is irrelevant
     TickType_t timestamp = xTaskGetTickCount();
 
     // there can only be 1 log writer at once
-    if (xSemaphoreTake(logWriteMutex, 50) != pdPASS)
-    {
+    if (xSemaphoreTake(logWriteMutex, 50) != pdPASS) {
         return false;
         // timed out while waiting to log - maybe too many tasks are waiting to log. this should never happen?
     }
@@ -93,51 +53,42 @@ bool logGeneric(LogDataSource_t source, LogLevel_t level, const char* msg, va_li
     log_buffer* currentBuffer = &logBuffers[CURRENT_BUFFER];
     
     // if current buffer is full, then all of them must be full. ERROR!!! do not proceed
-    if (currentBuffer->isFull)
-    {
+    if (currentBuffer->isFull) {
         xSemaphoreGive(logWriteMutex);
         return false;
     }
-    
-    // format and append the default log header
-	int headerLength = snprintf_(currentBuffer->buffer + currentBuffer->index, MAX_MSG_LENGTH, "%c: [%d] %s ", level, (int) timestamp, sourceToString(source));
-    currentBuffer->index += headerLength;
 
-    // limit the actual msg to `MAX_MSG_LENGTH - headerLength` to account for the header we just printed
-    int msgLength = vsnprintf_(currentBuffer->buffer + currentBuffer->index, MAX_MSG_LENGTH - headerLength, msg, msgArgs);
-    
-    // snprintf_ behaviour moment: it returns a larger number than the limit if it had to truncate
-	if (msgLength >= MAX_MSG_LENGTH - headerLength)
-    {
-        currentBuffer->index += MAX_MSG_LENGTH - headerLength - 1; // -1 cuz snprintf_ makes the last char \0
+    // format and append the log header and msg
+    int charsWritten = 0;
+    char* msgStart = currentBuffer->buffer + currentBuffer->index;
+
+    charsWritten += snprintf_(msgStart + charsWritten, MAX_MSG_LENGTH - charsWritten, "%c: [%d] %s ", level, (int) timestamp, source);
+    if (charsWritten >= MAX_MSG_LENGTH) {
+        charsWritten = MAX_MSG_LENGTH; // -1 to ignore the '\0' that snprintf automatically counts
     }
-    else
-    {
-        currentBuffer->index += msgLength; // no -1 here cuz snprintf_ normal return value doesn't count \0
+
+    charsWritten += vsnprintf_(msgStart + charsWritten, MAX_MSG_LENGTH - charsWritten, msg, msgArgs);
+    if (charsWritten >= MAX_MSG_LENGTH) {
+        charsWritten = MAX_MSG_LENGTH; // -1 to ignore the '\0' that snprintf automatically counts
     }
 
     // add \n in here instead of asking the sender to do it. This guarantees \n in all logs in case msg gets cut off
-    currentBuffer->buffer[currentBuffer->index] = '\n';
-    currentBuffer->index += 1;
+    currentBuffer->buffer[currentBuffer->index + charsWritten] = '\n';
+    currentBuffer->index += charsWritten + 1; // + 1 for the '\n'
 
-    // if buffer cannot be guaranteed to fit another msg, rotate buffers (which can be up to `MAX_MSG_LENGTH + \n` chars)
-    if (LOG_BUFFER_SIZE - currentBuffer->index < MAX_MSG_LENGTH + 1)
-    {
-        // do this before sending to queue in case queue is full. this prevents other loggers from writing to it
+    // check if this buffer can fit another msg of up to `MAX_MSG_LENGTH + '\n'` chars
+    if (LOG_BUFFER_SIZE - currentBuffer->index <= MAX_MSG_LENGTH) {
+        // set isFull before sending to queue in case queue is full. this prevents other loggers from writing to it
         currentBuffer->isFull = true;
 
-        // if full, send this buffer to output queue and move to next empty one
-        if (xQueueSendToBack(fullBuffersQueue, &currentBuffer, 0) != pdPASS)
-        {
-            // if queue does not have space, all n - 1 buffers are full which should not be possible!! ERROR!
+        // if full, send this buffer to output queue and rotate to next buffer
+        if (xQueueSendToBack(fullBuffersQueue, &currentBuffer, 0) != pdPASS) {
+            // if queue is full, all buffers are already in queue. how did we get here ??? ERROR!!!!
             xSemaphoreGive(logWriteMutex);
             return false;
         }
-        else
-        {
-            // rotate only if the queue write was successful. otherwise, stay on this buffer until queue hopefully empties
-            CURRENT_BUFFER = (CURRENT_BUFFER + 1) % NUM_LOG_BUFFERS;
-        }
+
+        CURRENT_BUFFER = (CURRENT_BUFFER + 1) % NUM_LOG_BUFFERS;
     }
 
     xSemaphoreGive(logWriteMutex);
@@ -148,8 +99,7 @@ bool logGeneric(LogDataSource_t source, LogLevel_t level, const char* msg, va_li
 // public log functions
 // ----------------------------------------------------------------------------
 
-bool logError(const LogDataSource_t source, const char* msg, ...)
-{
+bool logError(const char* source, const char* msg, ...) {
     va_list args;
     va_start(args, msg);
     bool success = logGeneric(source, LOG_LVL_ERROR, msg, args);
@@ -157,8 +107,7 @@ bool logError(const LogDataSource_t source, const char* msg, ...)
     return success;
 }
 
-bool logInfo(const LogDataSource_t source, const char* msg, ...)
-{
+bool logInfo(const char* source, const char* msg, ...) {
     va_list args;
     va_start(args, msg);
     bool success = logGeneric(source, LOG_LVL_INFO, msg, args);
@@ -166,8 +115,7 @@ bool logInfo(const LogDataSource_t source, const char* msg, ...)
     return success;
 }
 
-bool logDebug(const LogDataSource_t source, const char* msg, ...)
-{
+bool logDebug(const char* source, const char* msg, ...) {
 #ifdef DEBUG
     va_list args;
     va_start(args, msg);
@@ -179,8 +127,7 @@ bool logDebug(const LogDataSource_t source, const char* msg, ...)
 
 // ----------------------------------------------------------------------------
 
-void logTask(void *argument)
-{
+void logTask(void *argument) {
 	// initalize log file stuff
 	FATFS fs;
 	(void)f_mount(&fs, "", 0);
@@ -196,14 +143,10 @@ void logTask(void *argument)
     log_buffer* bufferToPrint;
 
     // wait for a full buffer to appear in the queue; timeout is long - queues are not expected to fill up super quickly
-    for (;;)
-    {
-		if (xQueueReceive(fullBuffersQueue, &bufferToPrint, 1000000) == pdPASS)
-        {
-                // TODO: do uart transmit better
-                // buffers fill from 0, so `index` conveniently indicates how many chars of data there are to print
-
+    for (;;) {
+		if (xQueueReceive(fullBuffersQueue, &bufferToPrint, 1000000) == pdPASS) {
             	(void)f_open(&logfile, logFileName, FA_OPEN_APPEND | FA_WRITE);
+                // buffers fill from 0, so `index` conveniently indicates how many chars of data there are to print
             	(void)f_write(&logfile, bufferToPrint->buffer, bufferToPrint->index, NULL);
             	(void)f_close(&logfile);
 

--- a/STM32Cube/Tasks/log.c
+++ b/STM32Cube/Tasks/log.c
@@ -149,7 +149,9 @@ void logTask(void *argument) {
                 // buffers fill from 0, so `index` conveniently indicates how many chars of data there are to print
             	(void)f_write(&logfile, bufferToPrint->buffer, bufferToPrint->index, NULL);
             	(void)f_close(&logfile);
-
+            	// uart print for testing
+            	// !!!! Ensure the timeout (rn 3000) is long enough to transmit a whole log chunk !!!
+            	// HAL_UART_Transmit(&huart4, bufferToPrint->buffer, bufferToPrint->index, 3000);
                 bufferToPrint->index = 0;
                 bufferToPrint->isFull = false;    
         }

--- a/STM32Cube/Tasks/log.h
+++ b/STM32Cube/Tasks/log.h
@@ -16,7 +16,7 @@ extern "C" {
 
 // TODO: determine optimal numbers for these
 /* max length of log data string (bytes) */
-#define MAX_MSG_LENGTH 128
+#define MAX_MSG_LENGTH 256
 /* size of one log buffer (bytes) */
 #define LOG_BUFFER_SIZE 8192
 /* number of log buffers */
@@ -31,21 +31,6 @@ typedef enum {
     LOG_LVL_INFO = 'I',   // Info (data from sensors, etc)
     LOG_LVL_DEBUG = 'D',  // Only for debugging on the ground
 } LogLevel_t;
-
-/**
- * Log data source
-*/
-typedef enum
-{
-    SOURCE_FLIGHT_EVENT,
-    SOURCE_HEALTH,
-    SOURCE_CAN_RX,
-    SOURCE_CAN_TX,
-    SOURCE_SENSOR,
-    SOURCE_STATE_EST,
-    SOURCE_APOGEE_PRED,
-    SOURCE_EXT_TARGET    
-} LogDataSource_t;
 
 /**
  * Buffer holding one block of log msgs
@@ -64,17 +49,17 @@ bool logInit(void);
 /**
  * Log an error-level message
 */
-bool logError(const LogDataSource_t source, const char* msg, ...);
+bool logError(const char* source, const char* msg, ...);
 
 /**
  * Log an info-level message
 */
-bool logInfo(const LogDataSource_t source, const char* msg, ...);
+bool logInfo(const char* source, const char* msg, ...);
 
 /**
  * Log a debug-level message
 */
-bool logDebug(const LogDataSource_t source, const char* msg, ...);
+bool logDebug(const char* source, const char* msg, ...);
 
 /**
  * FreeRTOS task for the logger

--- a/STM32Cube/Tasks/log.h
+++ b/STM32Cube/Tasks/log.h
@@ -51,7 +51,6 @@ typedef enum
  * Buffer holding one block of log msgs
 */
 typedef struct log_buffer {
-    SemaphoreHandle_t mutex;
     uint16_t index;
     char buffer[LOG_BUFFER_SIZE];
     bool isFull;


### PR DESCRIPTION
minor adjustments to hopefully increase certainty that logger won't overflow any buffers or get stuck.
- give back logwritemutex before exiting logGeneric (I thought josh fixed this already but I couldn't find that change?)
- get rid of counting the log header string separately from the log msg. It's all under MAX_MSG_LENGTH now for simplicity and less confusing/potentially incorrect logic.
- change fullBuffersQueue to length NUM_LOG_BUFFERS instead of `NUM_LOG_BUFFERS - 1`. reasoning described in comment
- replace stupid source enums with source strings