### PR TITLE
Sdcard otits

### DIFF
--- a/STM32Cube/Core/Src/ICM-20948.c
+++ b/STM32Cube/Core/Src/ICM-20948.c
@@ -104,7 +104,6 @@ Otits_Result_t test_magSelfTest() {
 	return res;
 }
 
-// This driver assumes that I2C is already initialized
 bool ICM_20948_init() {
     MY2C_init();
 

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -208,7 +208,6 @@ int main(void)
   trajectory_init();
   canHandlerInit(); //create bus queue
   flightPhaseInit();
-  MY2C_init();
   healthCheckInit();
   //canHandlerInit(); //create bus queue
   //flightPhaseInit();

--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -38,6 +38,7 @@
 #include "trajectory.h"
 #include "can_handler.h"
 #include "otits.h"
+#include "sdmmc.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -202,6 +203,7 @@ int main(void)
   /* USER CODE END RTOS_TIMERS */
 
   /* USER CODE BEGIN RTOS_QUEUES */
+  sdmmcInit();
   logInit();
   trajectory_init();
   canHandlerInit(); //create bus queue

--- a/STM32Cube/Tasks/log.c
+++ b/STM32Cube/Tasks/log.c
@@ -156,19 +156,22 @@ bool logDebug(const char* source, const char* msg, ...) {
 // ----------------------------------------------------------------------------
 
 void logTask(void *argument) {
-	// initalize log file stuff
-	FATFS fs;
-	(void)f_mount(&fs, "", 0);
-
-	(void)f_mkdir(logsPath);
-
-	(void)initUniqueLogFileName();
-
-	FIL logfile;
-	(void)f_open(&logfile, logFileName, FA_CREATE_ALWAYS);
-	(void)f_close(&logfile);
-
     log_buffer* bufferToPrint;
+    // initalize log file stuff
+    FATFS fs;
+    FRESULT res = FR_OK;
+
+    res |= f_mount(&fs, "", 0);
+    res |= f_mkdir(logsPath);
+    initUniqueLogFileName();
+
+    FIL logfile;
+    res |= f_open(&logfile, logFileName, FA_CREATE_ALWAYS);
+    res |= f_close(&logfile);
+
+    if (res != FR_OK && res != FR_EXIST) {
+        // flag init error
+    }
 
     // wait for a full buffer to appear in the queue; timeout is long - queues are not expected to fill up super quickly
     for (;;) {

--- a/STM32Cube/Tasks/otits.c
+++ b/STM32Cube/Tasks/otits.c
@@ -116,7 +116,7 @@ static bool otitsInit() {
 bool otitsRegister(Otits_Test_Function_t* testFunctionPtr, OtitsSource_e source, const char* name) {
 #ifdef TEST_MODE
 	// ensure not overflowing array
-	if (numTestsRegistered == MAX_NUM_TESTS) {
+	if (numTestsRegistered >= MAX_NUM_TESTS) {
 		printf_("ERROR: CANNOT REGISTER MORE TESTS %d THAN MAX_NUM_TESTS!\n", numTestsRegistered);
 		return false;
 	}

--- a/STM32Cube/Tasks/sdmmc.c
+++ b/STM32Cube/Tasks/sdmmc.c
@@ -1,8 +1,74 @@
 #include "sdmmc.h"
+#include "otits.h"
+#include <string.h>
 
 const char *logsPath = "/LOGS"; //path to the log file directory on the SD card
 char logFileName[LOG_FILE_NAME_SIZE];
 
+Otits_Result_t test_sdmmcWriteReadFile() {
+	Otits_Result_t res;
+	FIL testFileW;
+    FIL testFileR;
+	const char *testString = "otits";
+	size_t stringLen = strlen(testString);
+	// open a new empty test file
+	if (f_open(&testFileW, "test.txt", FA_CREATE_ALWAYS | FA_WRITE) != FR_OK) {
+        res.outcome = TEST_OUTCOME_FAILED;
+        res.info = "open fileW fail";
+		return res;
+	}
+
+	// write something
+	UINT bytesWritten = 0;
+	if (f_write(&testFileW, testString, stringLen, &bytesWritten) != FR_OK) {
+        res.outcome = TEST_OUTCOME_FAILED;
+        res.info = "write fileW fail";
+		return res;
+	} else if (bytesWritten != stringLen) {
+        res.outcome = TEST_OUTCOME_FAILED;
+        res.info = "bytesWritten incorrect";
+		return res;
+	}
+
+    // close the file
+    if (f_close(&testFileW) != FR_OK) {
+        res.outcome = TEST_OUTCOME_FAILED;
+        res.info = "close fileW fail";
+        return res;
+    }
+
+    // open again to check that the file was actually created
+    if (f_open(&testFileR, "test.txt", FA_OPEN_EXISTING | FA_READ) != FR_OK) {
+        res.outcome = TEST_OUTCOME_FAILED;
+        res.info = "open fileR fail";
+        return res;
+    }
+
+	// read the msg
+	BYTE buf[5];
+	UINT bytesRead = 0;
+	if (f_read(&testFileR, buf, stringLen, &bytesRead) != FR_OK) {
+        res.outcome = TEST_OUTCOME_FAILED;
+        res.info = "read fileR fail";
+		return res;
+	} else if (strncmp(testString, buf, 5) != 0) {
+	    f_close(&testFileR); // try to close it here so future tests don't get locked out
+        res.outcome = TEST_OUTCOME_FAILED;
+        res.info = "strcmp fail";
+		return res;
+	}
+
+	// close the file again
+	if (f_close(&testFileR) != FR_OK) {
+        res.outcome = TEST_OUTCOME_FAILED;
+        res.info = "close fileR fail";
+		return res;
+	}
+
+	res.info = "";
+	res.outcome = TEST_OUTCOME_PASSED;
+	return res;
+}
 
 //Count the number of files inside of a directory
 static int computeFolderSize(const char *path) {

--- a/STM32Cube/Tasks/sdmmc.c
+++ b/STM32Cube/Tasks/sdmmc.c
@@ -5,7 +5,7 @@
 const char *logsPath = "/LOGS"; //path to the log file directory on the SD card
 char logFileName[LOG_FILE_NAME_SIZE];
 
-Otits_Result_t test_sdmmcWriteReadFile() {
+static Otits_Result_t test_sdmmcWriteReadFile() {
 	Otits_Result_t res;
 	FIL testFileW;
     FIL testFileR;
@@ -68,6 +68,11 @@ Otits_Result_t test_sdmmcWriteReadFile() {
 	res.info = "";
 	res.outcome = TEST_OUTCOME_PASSED;
 	return res;
+}
+
+bool sdmmcInit() {
+	if (!otitsRegister(test_sdmmcWriteReadFile, TEST_SOURCE_SDMMC, "fatfs")) return false;
+	return true;
 }
 
 //Count the number of files inside of a directory

--- a/STM32Cube/Tasks/sdmmc.h
+++ b/STM32Cube/Tasks/sdmmc.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <stdarg.h>
 #include <string.h>
+#include <stdbool.h>
 #include "printf.h"
 #include "stm32h7xx_hal.h"
 #include "FreeRTOS.h"
@@ -15,6 +16,7 @@ extern "C" {
 
 // function declarations
 void initUniqueLogFileName();
+bool sdmmcInit();
 
 // variable declarations
 


### PR DESCRIPTION
idk how valid this otits test is. It would be nice to open and read the actual logger file, but I think that conflicts since you can't open the same file in two threads (?), and adding guards is not in the scope of this. So the purpose of this test is just to make sure sd card is in fact connected and able to open/write/read an arbitrary file.

Also created a separate `sdmmcInit()` method to separate the fatfs stuff from logger a bit, pls review if this works or not.

This branch is branched off the logger one, so just ignore all the changes to logger. Only relevant files are the sdmmc and main.