### PR TITLE
update canlib, remove ConfName define

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Processor is a bit different from most other rocketCAN boards as it uses an STM3
 
 To get started with development, clone the repository and open the IDE project folder in the workspace directory of your choice. You will also need to initialize the submodules in the project using 
 
-`git submodule update --init`
-
-As of writing, you will need to check the ```canlib``` submodule out to the correct working branch, in this case ```stm32h7```.
+`git submodule update --init --recursive`
 
 Otherwise this process is fairly standard across Eclipse-based IDEs, so any issues should be resolvable with some Google-fu.
 

--- a/STM32Cube/.cproject
+++ b/STM32Cube/.cproject
@@ -49,7 +49,6 @@
 									<listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
 									<listOptionValue builtIn="false" value="STM32_THREAD_SAFE_STRATEGY=4"/>
 									<listOptionValue builtIn="false" value="BOARD_UNIQUE_ID=0x08"/>
-									<listOptionValue builtIn="false" value="ConfName=STM32H733XX"/>
 									<listOptionValue builtIn="false" value="STM32H733xx"/>
 								</option>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths.2062664197" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">

--- a/STM32Cube/Tasks/trajectory.c
+++ b/STM32Cube/Tasks/trajectory.c
@@ -228,7 +228,7 @@ float get_max_altitude(float velY, float velX, float altitude, float airbrake_ex
 
 void trajectory_task(void * argument){    
     float prev_time = -1;
-    uint16_t prev_alt = 0xFFFFFFFF;
+    uint16_t prev_alt = 0xFFFF;
     
     //TEST CODE
     AltTime altTimeTEST;
@@ -253,7 +253,7 @@ void trajectory_task(void * argument){
         if(xQueueReceive(altQueue, &altTime, 10) == pdTRUE) {
             if(xQueuePeek(extQueue, &ext, 10)== pdTRUE) {
                 if(xQueuePeek(angleQueue, &angles, 100) == pdTRUE) {
-                    if(prev_alt != 0xFFFFFFFF) {
+                    if(prev_alt != 0xFFFF) {
                         float vely = (altTime.alt-prev_alt)*1000.0/(altTime.time-prev_time);
                         float velx = vely*tan(angles.angle.pitch);
                         float apogee = get_max_altitude(vely,velx, altTime.alt, ext, ROCKET_BURNOUT_MASS);


### PR DESCRIPTION
finally no warning on `can_init_stm` 
![image](https://github.com/waterloo-rocketry/cansw_processor_stm/assets/71736183/46ec977e-1dff-4b88-a8d4-dc74a6073cdb)

also modify trajectory test code to remove type conversion warning, hopefully that one wasn't intentional