### PR TITLE
Add macros to enforce not using default printfs

### DIFF
--- a/STM32Cube/printf/printf.h
+++ b/STM32Cube/printf/printf.h
@@ -39,6 +39,16 @@
 #ifndef PRINTF_H_
 #define PRINTF_H_
 
+// Added to enforce not using the default printf
+#define printf do_not_use_default_printf
+#define fprintf do_not_use_default_printf
+#define sprintf do_not_use_default_printf
+#define snprintf do_not_use_default_printf
+#define printf_s do_not_use_default_printf
+#define fprintf_s do_not_use_default_printf
+#define sprintf_s do_not_use_default_printf
+#define snprintf_s do_not_use_default_printf
+
 #ifdef __cplusplus
 # include <cstdarg>
 # include <cstddef>


### PR DESCRIPTION
This is my contribution to code quality here.

This ensures that if you try to use a default printf-like function, you will get a compile error.

However, this will only work if you actually included the right printf header, so it might not be that effective. Maybe it could go in a different header?