### PR TITLE
User def callback

### DIFF
--- a/STM32Cube/Core/Src/main.c
+++ b/STM32Cube/Core/Src/main.c
@@ -213,6 +213,7 @@ int main(void)
   healthCheckInit();
   controllerInit();
   state_est_init();
+  vn_handler_init();
 
   otitsRegister(test_defaultTaskPass, TEST_SOURCE_DEFAULT, "DefaultPass");
   otitsRegister(test_defaultTaskFail, TEST_SOURCE_DEFAULT, "DefaultFail");

--- a/STM32Cube/Tasks/vn_handler.c
+++ b/STM32Cube/Tasks/vn_handler.c
@@ -21,16 +21,15 @@ const uint32_t  DMA_RX_TIMEOUT = 300;
 const uint8_t MS_WAIT_CAN = 10;
 const uint32_t NS_TO_S = 1000000000;
 const uint32_t NS_TO_MS = 1000000;
+const uint32_t ASCII_METERS = 109;
 const bool verbose = false;
 
 uint8_t USART1_Rx_Buffer[MAX_BINARY_OUTPUT_LENGTH];
 SemaphoreHandle_t USART1_DMA_Sempahore;
 
-const uint32_t ASCII_METERS = 109;
-
-void VN_UASART1_RX_callback(UART_HandleTypeDef *huart, uint16_t Pos) //this rebinds the generic _weak callback
+void VN_UASART1_RX_callback(UART_HandleTypeDef *huart, uint16_t Pos)
 {
-	if(huart == &huart1 && huart->RxEventType == 0x02U) //transfer complete event on USART1
+	if(huart == &huart1 && huart->RxEventType == 0x02U) //IDLE event on USART1
 		{
 			BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 			xSemaphoreGiveFromISR(USART1_DMA_Sempahore, &xHigherPriorityTaskWoken);
@@ -85,7 +84,7 @@ static void send3VectorStateCanMsg_double(uint64_t time, double vector[3], uint8
 
 void vnIMUHandler(void *argument)
 {
-	HAL_UART_RegisterRxEventCallback(&huart1, VN_UASART1_RX_callback); //TODO: use user-defined callback binding
+	HAL_UART_RegisterRxEventCallback(&huart1, VN_UASART1_RX_callback);
 	USART1_DMA_Sempahore = xSemaphoreCreateBinary();
 
 	for(;;)

--- a/STM32Cube/Tasks/vn_handler.c
+++ b/STM32Cube/Tasks/vn_handler.c
@@ -81,12 +81,15 @@ static void send3VectorStateCanMsg_double(uint64_t time, double vector[3], uint8
 	send3VectorStateCanMsg_float(time, float_vector, firstStateIDOfVector);
 }
 
+void vn_handler_init()
+{
+	HAL_StatusTypeDef status = HAL_UART_RegisterRxEventCallback(&huart1, VN_UASART1_RX_callback);
+	USART1_DMA_Sempahore = xSemaphoreCreateBinary();
+}
+
 
 void vnIMUHandler(void *argument)
 {
-	HAL_UART_RegisterRxEventCallback(&huart1, VN_UASART1_RX_callback);
-	USART1_DMA_Sempahore = xSemaphoreCreateBinary();
-
 	for(;;)
 	{
 		//Begin a receive, until we read MAX_BINARY_OUTPUT_LENGTH or the line goes idle, indicating a shorter message

--- a/STM32Cube/Tasks/vn_handler.c
+++ b/STM32Cube/Tasks/vn_handler.c
@@ -81,10 +81,12 @@ static void send3VectorStateCanMsg_double(uint64_t time, double vector[3], uint8
 	send3VectorStateCanMsg_float(time, float_vector, firstStateIDOfVector);
 }
 
-void vn_handler_init()
+bool vn_handler_init()
 {
 	HAL_StatusTypeDef status = HAL_UART_RegisterRxEventCallback(&huart1, VN_UASART1_RX_callback);
 	USART1_DMA_Sempahore = xSemaphoreCreateBinary();
+
+	return (status == HAL_OK) && (USART1_DMA_Sempahore != NULL);
 }
 
 

--- a/STM32Cube/Tasks/vn_handler.c
+++ b/STM32Cube/Tasks/vn_handler.c
@@ -28,9 +28,9 @@ SemaphoreHandle_t USART1_DMA_Sempahore;
 
 const uint32_t ASCII_METERS = 109;
 
-void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t Size) //this rebinds the generic _weak callback
+void VN_UASART1_RX_callback(UART_HandleTypeDef *huart, uint16_t Pos) //this rebinds the generic _weak callback
 {
-	if(huart == &huart1)
+	if(huart == &huart1 && huart->RxEventType == 0x02U) //transfer complete event on USART1
 		{
 			BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 			xSemaphoreGiveFromISR(USART1_DMA_Sempahore, &xHigherPriorityTaskWoken);
@@ -85,10 +85,9 @@ static void send3VectorStateCanMsg_double(uint64_t time, double vector[3], uint8
 
 void vnIMUHandler(void *argument)
 {
-	//HAL_UART_RegisterCallback(&huart4, HAL_UART_RX_COMPLETE_CB_ID, USART1_DMA_Rx_Complete_Callback); //TODO: use user-defined callback binding
+	HAL_UART_RegisterRxEventCallback(&huart1, VN_UASART1_RX_callback); //TODO: use user-defined callback binding
 	USART1_DMA_Sempahore = xSemaphoreCreateBinary();
-	printf_("Starting...\r\n");
-	//logInfo("##VN Handler Task","2024-07-05-4:30pm");
+
 	for(;;)
 	{
 		//Begin a receive, until we read MAX_BINARY_OUTPUT_LENGTH or the line goes idle, indicating a shorter message

--- a/STM32Cube/Tasks/vn_handler.h
+++ b/STM32Cube/Tasks/vn_handler.h
@@ -14,6 +14,6 @@
 #include <stdbool.h>
 
 void vnIMUHandler(void *argument);
-void vn_handler_init();
+bool vn_handler_init();
 
 #endif /* VN_HANDLER_H_ */

--- a/STM32Cube/Tasks/vn_handler.h
+++ b/STM32Cube/Tasks/vn_handler.h
@@ -14,5 +14,6 @@
 #include <stdbool.h>
 
 void vnIMUHandler(void *argument);
+void vn_handler_init();
 
 #endif /* VN_HANDLER_H_ */


### PR DESCRIPTION
Closes #43 

Tested with VN before and after changes, seems to work fine. Our buffer length is 200 but our longest message is less than 100. This should stop the callback from triggering on complete or half complete, and only on an IDLE event. Just in case, I'm also checking the event type in the callback as well