### PR TITLE
lowpass velocity calculation; add threshold for velocity-based lockout

### DIFF
--- a/STM32Cube/Calculations/trajectory_lib.c
+++ b/STM32Cube/Calculations/trajectory_lib.c
@@ -235,7 +235,7 @@ float getMaxAltitude_m(float vy_m_s, float vx_m_s, float y_m) {
 float second_order_lowpass_filter(float input, float* values, float alpha) {
     float beta = 1 - alpha;
 
-	output = alpha * alpha * input + 2 * alpha * beta * values[0] - beta * beta * values[1];
+	float output = alpha * alpha * input + 2 * alpha * beta * values[0] - beta * beta * values[1];
 
 	values[1] = values[0];
 	values[0] = output;

--- a/STM32Cube/Calculations/trajectory_lib.c
+++ b/STM32Cube/Calculations/trajectory_lib.c
@@ -231,3 +231,13 @@ float getMaxAltitude_m(float vy_m_s, float vx_m_s, float y_m) {
 
     return prevAlt;
 }
+
+float second_order_lowpass_filter(float input, float* values, float alpha) {
+    float beta = 1 - alpha;
+
+	output = alpha * alpha * input + 2 * alpha * beta * values[0] - beta * beta * values[1];
+
+	values[1] = values[0];
+	values[0] = output;
+	return output;
+}

--- a/STM32Cube/Calculations/trajectory_lib.h
+++ b/STM32Cube/Calculations/trajectory_lib.h
@@ -2,6 +2,7 @@
 #define TRAJECTORY_LIB_H_
 
 #define EXTENSION_REFERENCE 0.58f
+#define VELOCITY_FILTER_ALPHA 0.1f
 
 /**
  * Returns the acceleration due to drag acting on the rocket.
@@ -13,5 +14,7 @@ float dragAccel_m_s2(float extension, float speed_m_s, float altitude_m);
  * mass given the current velocity and altitude.
  */
 float getMaxAltitude_m(float vy_m_s, float vx_m_s, float y_m);
+
+float second_order_lowpass_filter(float* input, float alpha);
 
 #endif

--- a/STM32Cube/Calculations/trajectory_lib.h
+++ b/STM32Cube/Calculations/trajectory_lib.h
@@ -15,6 +15,6 @@ float dragAccel_m_s2(float extension, float speed_m_s, float altitude_m);
  */
 float getMaxAltitude_m(float vy_m_s, float vx_m_s, float y_m);
 
-float second_order_lowpass_filter(float* input, float alpha);
+float second_order_lowpass_filter(float input, float* values, float alpha);
 
 #endif

--- a/STM32Cube/Tasks/flight_phase.h
+++ b/STM32Cube/Tasks/flight_phase.h
@@ -29,6 +29,7 @@ extern EventGroupHandle_t flightPhaseEventsHandle;
 
 
 bool extensionAllowed();
+bool recoveryPhase();
 
 void flightPhaseTask(void * argument);
 bool flightPhaseInit();

--- a/STM32Cube/Tasks/flight_phase.h
+++ b/STM32Cube/Tasks/flight_phase.h
@@ -25,6 +25,7 @@ extern EventGroupHandle_t flightPhaseEventsHandle;
 #define INJ_OPEN_BIT 0x1
 #define RECOVERY_DEPLOYMENT_BIT 0x2
 #define RECOVERY_MIN_VELOCITY 30.0
+#define RECOVERY_TIMEOUT_READINGS 5 //Number of consecutive readings below threshold after which recovery lockout should be enabled
 
 
 bool extensionAllowed();


### PR DESCRIPTION
- Added a 2nd order IIR lowpass filter to velocity, alpha = 0.1 was tested in python and yielded this
![image](https://github.com/user-attachments/assets/40075c63-0f72-43c4-a619-960bc664f0b6)
- Added requirement that we see 5 consecutive readings below the velocity threshold to trigger activation. This corresponds to the orange line on the above graph going high. Note that due to the coast phase condition we would only be looking at it starting around sample 5250 in the graph, so the false positives at boost are not a concern.